### PR TITLE
Remove 'file/temp' dep

### DIFF
--- a/adventure
+++ b/adventure
@@ -2,7 +2,6 @@
 
 require 'open3'
 require 'yaml'
-require 'file/temp'
 
 class Page
   attr_reader :name, :actions, :death


### PR DESCRIPTION
Was failing on my agent running `ruby 2.0.0p648 (2015-12-16)` - this needed?
